### PR TITLE
config: package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      # it follows package.json  "packageManager": "pnpm@9.15.0",
+        # with:
+          # version: 9
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "@base/source",
-  "version": "0.0.0",
-  "license": "MIT",
-  "scripts": {},
+  "name": "root",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leeffeciency/es-ramda.git"
+  },
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {
     "@nx/js": "20.3.3",


### PR DESCRIPTION
## The role of `private: true` in `package.json`

The `private: true` field in package.json serves as a crucial safety mechanism in Node.js projects. Let me explain its purpose and functionality in detail.

By default, any directory containing a package.json file is potentially publishable to npm. This means that accidentally running `npm publish` could unintentionally publish your package to the public npm registry. Setting `private: true` activates important protective features:

```json
{
  "name": "my-monorepo",
  "private": true,  // This package will never be published to npm
  "workspaces": ["packages/*"]
}
```

To understand why this setting is particularly important, let's examine some real-world scenarios:

Consider a monorepo structure:
```
my-monorepo/
├── package.json (private: true)
├── packages/
│   ├── ui-library/
│   │   └── package.json
│   └── utils/
│       └── package.json
```
In this structure, the root package.json serves as a configuration file for the development environment, not as a package meant for distribution. The `private: true` setting prevents accidental publication of this configuration.

For internal company packages:
```json
{
  "name": "@company/internal-utils",
  "private": true,
  "version": "1.0.0"
}
```
This package is intended for internal company use only, and the private flag prevents accidental publication to public registries.

Let's examine what could go wrong without `private: true`:
```bash
# Intention: Publish a specific package
cd packages/ui-library
npm publish

# Mistake: Running from root directory
cd ../../
npm publish  # Without private: true, the entire monorepo would be published!
```

The benefits extend beyond just preventing publication:
1. Clear Intent Communication: It explicitly signals to team members that this package isn't meant for distribution
2. CI/CD Protection: Prevents accidental publication during automated deployment processes
3. Workspace Management: Enhances safety when used with npm/yarn/pnpm workspace features

In a monorepo context, you might see:
```json
{
  "name": "monorepo-root",
  "private": true,
  "workspaces": ["packages/*"],
  "scripts": {
    "build": "nx build",
    "test": "nx test"
  }
}
```
This configuration clearly establishes that the root package.json serves as a development tool rather than a distributable package.

Understanding the implications of `private: true` becomes even more critical in modern JavaScript development, where monorepos and complex package structures are increasingly common. While it's a simple boolean flag, it serves as a fundamental safeguard against security incidents and unintended publications.

This safety mechanism is particularly vital in enterprise environments where accidental publication of internal code could have serious consequences. When combined with workspace management tools and modern build systems, `private: true` helps maintain the integrity of your package management strategy while preventing potential security breaches through inadvertent publication.

In the context of monorepos, this setting has become almost mandatory, as it helps maintain clear boundaries between publishable packages and internal development configurations. It's a simple yet powerful tool in the modern JavaScript development toolkit, providing peace of mind and clear intent in package management.
`private: true` 필드는 package.json에서 매우 중요한 안전장치 역할을 합니다. 이 설정의 목적과 작동 방식을 자세히 살펴보겠습니다.

기본적으로, package.json이 있는 모든 디렉토리는 잠재적으로 npm에 배포될 수 있는 패키지입니다. 이는 실수로 `npm publish` 명령어를 실행했을 때 의도치 않게 패키지가 공개 npm 레지스트리에 배포될 수 있다는 것을 의미합니다.

## `package.json` 에서 `private: true` 의 역할
`private: true`를 설정하면 다음과 같은 보호 기능이 작동합니다:

```json
{
  "name": "my-monorepo",
  "private": true,  // 이 패키지는 절대 npm에 배포되지 않습니다
  "workspaces": ["packages/*"]
}
```

이 설정이 특히 중요한 이유를 시나리오를 통해 이해해보겠습니다:

1. 모노레포 보호
```
my-monorepo/
├── package.json (private: true)
├── packages/
│   ├── ui-library/
│   │   └── package.json
│   └── utils/
│       └── package.json
```
이 구조에서 루트의 package.json은 실제 배포될 패키지가 아닌, 개발 환경을 위한 설정 파일입니다. 따라서 이것이 실수로 npm에 배포되는 것은 막아야 합니다.

2. 내부 패키지 보호
예를 들어, 회사 내부용 패키지를 개발할 때:
```json
{
  "name": "@company/internal-utils",
  "private": true,
  "version": "1.0.0"
}
```
이 패키지는 회사 내부에서만 사용되어야 하므로, 실수로 공개 레지스트리에 배포되는 것을 방지합니다.

`private: true`가 없을 때 발생할 수 있는 실제 문제:
```bash
# 의도: 특정 패키지만 배포하려고 했으나
cd packages/ui-library
npm publish

# 실수: 루트 디렉토리에서 실행
cd ../../
npm publish  # private: true가 없다면, 전체 모노레포가 배포됩니다!
```

추가적인 이점들:
1. 의도 명확화: 이 패키지가 배포용이 아님을 팀원들에게 명확히 전달
2. CI/CD 보호: 자동화된 배포 과정에서 실수로 배포되는 것을 방지
3. 워크스페이스 관리: npm/yarn/pnpm의 워크스페이스 기능과 함께 사용될 때 더욱 안전한 패키지 관리 가능

모노레포에서의 특별한 활용:
```json
{
  "name": "monorepo-root",
  "private": true,
  "workspaces": ["packages/*"],
  "scripts": {
    "build": "nx build",
    "test": "nx test"
  }
}
```
이 설정은 루트 package.json이 배포용이 아닌 개발 도구로서의 역할만 수행함을 명확히 합니다.

이처럼 `private: true`는 단순한 설정 하나로 보이지만, 실수로 인한 보안 사고나 의도치 않은 배포를 방지하는 중요한 안전장치 역할을 합니다. 특히 모노레포 환경에서는 이 설정이 거의 필수적이라고 할 수 있습니다.